### PR TITLE
refactor: migrate wiki ep pushRev to Drizzle

### DIFF
--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -800,7 +800,7 @@ export const chiiRevHistory = mysqlTable(
     revType: tinyint('rev_type').notNull(),
     revMid: mediumint('rev_mid').notNull(),
     revTextId: mediumint('rev_text_id').notNull(),
-    revDateline: int('rev_dateline').notNull(),
+    createdAt: int('rev_dateline').notNull(),
     revCreator: mediumint('rev_creator').notNull(),
     revEditSummary: varchar('rev_edit_summary', { length: 200 }).notNull(),
   },

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -815,8 +815,7 @@ export const chiiRevHistory = mysqlTable(
 
 export const chiiRevText = mysqlTable('chii_rev_text', {
   revTextId: mediumint('rev_text_id').autoincrement().notNull(),
-  // Warning: Can't parse mediumblob from database
-  // mediumblobType: mediumblob("rev_text").notNull(),
+  revText: mediumblob('rev_text').notNull(),
 });
 
 export const chiiSubjects = mysqlTable('chii_subjects', {

--- a/lib/rev/ep.test.ts
+++ b/lib/rev/ep.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from 'vitest';
 
-import { AppDataSource } from '@app/lib/orm/index.ts';
+import { db } from '@app/drizzle/db.ts';
 
 import { pushRev } from './ep.ts';
 
 test('get episode rev', async () => {
   // const r = await getRev(15, 8);
   // expect(r).toMatchInlineSnapshot('Array []');
-  await AppDataSource.transaction(async (t) => {
+  await db.transaction(async (t) => {
     await expect(
       pushRev(t, {
         episodeID: 8,

--- a/lib/rev/ep.test.ts
+++ b/lib/rev/ep.test.ts
@@ -1,7 +1,6 @@
 import { expect, test } from 'vitest';
-import { and, eq } from 'drizzle-orm';
 
-import { db } from '@app/drizzle/db.ts';
+import { db, op } from '@app/drizzle/db.ts';
 import * as schema from '@app/drizzle/schema.ts';
 import { RevType } from '@app/lib/orm/entity/index.ts';
 
@@ -14,9 +13,9 @@ test('get episode rev', async () => {
   await db
     .delete(schema.chiiRevHistory)
     .where(
-      and(
-        eq(schema.chiiRevHistory.revMid, 8),
-        eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
+      op.and(
+        op.eq(schema.chiiRevHistory.revMid, 8),
+        op.eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
       ),
     )
     .execute();
@@ -44,9 +43,9 @@ test('get episode rev', async () => {
       .select()
       .from(schema.chiiRevHistory)
       .where(
-        and(
-          eq(schema.chiiRevHistory.revMid, 8),
-          eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
+        op.and(
+          op.eq(schema.chiiRevHistory.revMid, 8),
+          op.eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
         ),
       )
       .execute();

--- a/lib/rev/ep.ts
+++ b/lib/rev/ep.ts
@@ -1,19 +1,9 @@
 import type { Txn } from '@app/drizzle/db.ts';
 import { db, op } from '@app/drizzle/db.ts';
 import * as schema from '@app/drizzle/schema.ts';
-import type { EpTextRev } from '@app/lib/orm/entity/index.ts';
+import type { EpTextRev, RevHistory } from '@app/lib/orm/entity/index.ts';
 import { RevType } from '@app/lib/orm/entity/index.ts';
 import * as entity from '@app/lib/orm/entity/index.ts';
-
-interface RevHistory {
-  revId: number;
-  revType: number;
-  revMid: number;
-  revTextId: number;
-  revDateline: number;
-  revCreator: number;
-  revEditSummary: string;
-}
 
 export async function pushRev(
   t: Txn,
@@ -95,7 +85,7 @@ async function updatePreviousRevRecords({
     revType: RevType.episodeEdit,
     revCreator: creator,
     revTextId: revText.revTextId,
-    revDateline: now.getTime() / 1000,
+    createdAt: now.getTime() / 1000,
     revMid: episodeID,
     revEditSummary: comment,
   });
@@ -135,7 +125,7 @@ async function createRevRecords({
     revType: RevType.episodeEdit,
     revCreator: creator,
     revTextId: revTextId,
-    revDateline: now.getTime() / 1000,
+    createdAt: now.getTime() / 1000,
     revMid: episodeID,
     revEditSummary: comment,
   });

--- a/lib/rev/ep.ts
+++ b/lib/rev/ep.ts
@@ -1,11 +1,24 @@
-import type { EntityManager } from 'typeorm';
+import { and, eq } from 'drizzle-orm';
 
-import type { EpTextRev, RevHistory } from '@app/lib/orm/entity/index.ts';
+import type { Txn } from '@app/drizzle/db.ts';
+import { db } from '@app/drizzle/db.ts';
+import * as schema from '@app/drizzle/schema.ts';
+import type { EpTextRev } from '@app/lib/orm/entity/index.ts';
 import { RevType } from '@app/lib/orm/entity/index.ts';
 import * as entity from '@app/lib/orm/entity/index.ts';
 
+interface RevHistory {
+  revId: number;
+  revType: number;
+  revMid: number;
+  revTextId: number;
+  revDateline: number;
+  revCreator: number;
+  revEditSummary: string;
+}
+
 export async function pushRev(
-  t: EntityManager,
+  t: Txn,
   {
     episodeID,
     rev,
@@ -20,10 +33,16 @@ export async function pushRev(
     comment: string;
   },
 ) {
-  const revs = await t.findBy(entity.RevHistory, {
-    revMid: episodeID,
-    revType: RevType.episodeEdit,
-  });
+  const revs = await db
+    .select()
+    .from(schema.chiiRevHistory)
+    .where(
+      and(
+        eq(schema.chiiRevHistory.revMid, episodeID),
+        eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
+      ),
+    )
+    .execute();
   const o = revs.pop();
   if (!o) {
     return await createRevRecords({
@@ -56,7 +75,7 @@ async function updatePreviousRevRecords({
   now,
   comment,
 }: {
-  t: EntityManager;
+  t: Txn;
   previous: RevHistory;
   episodeID: number;
   rev: EpTextRev;
@@ -64,26 +83,35 @@ async function updatePreviousRevRecords({
   now: Date;
   comment: string;
 }) {
-  const revText = await t.findOneOrFail(entity.RevText, {
-    where: {
-      revTextId: previous.revTextId,
-    },
-  });
+  const [revText] = await t
+    .select()
+    .from(schema.chiiRevText)
+    .where(eq(schema.chiiRevText.revTextId, previous.revTextId))
+    .execute();
 
-  const revHistory = await t.save(entity.RevHistory, {
+  if (!revText) {
+    throw new Error(`RevText not found for ID: ${previous.revTextId}`);
+  }
+
+  const [{ insertId: revId }] = await t.insert(schema.chiiRevHistory).values({
     revType: RevType.episodeEdit,
     revCreator: creator,
     revTextId: revText.revTextId,
-    createdAt: now.getTime() / 1000,
+    revDateline: now.getTime() / 1000,
     revMid: episodeID,
     revEditSummary: comment,
   });
 
   revText.revText = await entity.RevText.serialize({
     ...(await entity.RevText.deserialize(revText.revText)),
-    [revHistory.revId]: rev,
+    [revId]: rev,
   });
-  await t.save(entity.RevText, revText);
+  await t
+    .update(schema.chiiRevText)
+    .set({
+      revText: revText.revText,
+    })
+    .where(eq(schema.chiiRevText.revTextId, revText.revTextId));
 }
 
 async function createRevRecords({
@@ -94,26 +122,31 @@ async function createRevRecords({
   now,
   comment,
 }: {
-  t: EntityManager;
+  t: Txn;
   episodeID: number;
   rev: EpTextRev;
   creator: number;
   now: Date;
   comment: string;
 }) {
-  const revText = await t.save(entity.RevText, {
+  const [{ insertId: revTextId }] = await t.insert(schema.chiiRevText).values({
     revText: await entity.RevText.serialize({}),
   });
 
-  const revHistory = await t.save(entity.RevHistory, {
+  const [{ insertId: revId }] = await t.insert(schema.chiiRevHistory).values({
     revType: RevType.episodeEdit,
     revCreator: creator,
-    revTextId: revText.revTextId,
-    createdAt: now.getTime() / 1000,
+    revTextId: revTextId,
+    revDateline: now.getTime() / 1000,
     revMid: episodeID,
     revEditSummary: comment,
   });
 
-  revText.revText = await entity.RevText.serialize({ [revHistory.revId]: rev });
-  await t.save(entity.RevText, revText);
+  const revText = await entity.RevText.serialize({ [revId]: rev });
+  await t
+    .update(schema.chiiRevText)
+    .set({
+      revText: revText,
+    })
+    .where(eq(schema.chiiRevText.revTextId, revTextId));
 }

--- a/lib/rev/ep.ts
+++ b/lib/rev/ep.ts
@@ -1,7 +1,5 @@
-import { and, eq } from 'drizzle-orm';
-
 import type { Txn } from '@app/drizzle/db.ts';
-import { db } from '@app/drizzle/db.ts';
+import { db, op } from '@app/drizzle/db.ts';
 import * as schema from '@app/drizzle/schema.ts';
 import type { EpTextRev } from '@app/lib/orm/entity/index.ts';
 import { RevType } from '@app/lib/orm/entity/index.ts';
@@ -37,9 +35,9 @@ export async function pushRev(
     .select()
     .from(schema.chiiRevHistory)
     .where(
-      and(
-        eq(schema.chiiRevHistory.revMid, episodeID),
-        eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
+      op.and(
+        op.eq(schema.chiiRevHistory.revMid, episodeID),
+        op.eq(schema.chiiRevHistory.revType, RevType.episodeEdit),
       ),
     )
     .execute();
@@ -86,7 +84,7 @@ async function updatePreviousRevRecords({
   const [revText] = await t
     .select()
     .from(schema.chiiRevText)
-    .where(eq(schema.chiiRevText.revTextId, previous.revTextId))
+    .where(op.eq(schema.chiiRevText.revTextId, previous.revTextId))
     .execute();
 
   if (!revText) {
@@ -111,7 +109,7 @@ async function updatePreviousRevRecords({
     .set({
       revText: revText.revText,
     })
-    .where(eq(schema.chiiRevText.revTextId, revText.revTextId));
+    .where(op.eq(schema.chiiRevText.revTextId, revText.revTextId));
 }
 
 async function createRevRecords({
@@ -148,5 +146,5 @@ async function createRevRecords({
     .set({
       revText: revText,
     })
-    .where(eq(schema.chiiRevText.revTextId, revTextId));
+    .where(op.eq(schema.chiiRevText.revTextId, revTextId));
 }

--- a/routes/private/routes/wiki/subject/ep.ts
+++ b/routes/private/routes/wiki/subject/ep.ts
@@ -2,9 +2,10 @@ import type { Static } from '@sinclair/typebox';
 import { Type as t } from '@sinclair/typebox';
 import * as lo from 'lodash-es';
 
+import { db } from '@app/drizzle/db.ts';
 import { BadRequestError, NotFoundError } from '@app/lib/error.ts';
 import { Security, Tag } from '@app/lib/openapi/index.ts';
-import { AppDataSource, EpisodeRepo } from '@app/lib/orm/index.ts';
+import { EpisodeRepo } from '@app/lib/orm/index.ts';
 import { pushRev } from '@app/lib/rev/ep.ts';
 import * as res from '@app/lib/types/res.ts';
 import { formatErrors } from '@app/lib/types/res.ts';
@@ -217,7 +218,7 @@ export async function setup(app: App) {
 
       const now = new Date();
 
-      await AppDataSource.transaction(async (t) => {
+      await db.transaction(async (t) => {
         await pushRev(t, {
           episodeID,
           rev: {


### PR DESCRIPTION
沿用了一些 `@app/lib/orm/entity/index.ts` 里的定义和方法，暂时没动