### PR TITLE
feat: make wiki ep pushRev take an array of revisions

### DIFF
--- a/lib/rev/ep.test.ts
+++ b/lib/rev/ep.test.ts
@@ -22,16 +22,20 @@ test('get episode rev', async () => {
   await db.transaction(async (t) => {
     await expect(
       pushRev(t, {
-        episodeID: 8,
-        rev: {
-          ep_airdate: '1234-08-10',
-          ep_desc: 'description',
-          ep_duration: '20:10',
-          ep_name: 'n',
-          ep_name_cn: 'nnn',
-          ep_sort: '0',
-          ep_type: '0',
-        },
+        revisions: [
+          {
+            episodeID: 8,
+            rev: {
+              ep_airdate: '1234-08-10',
+              ep_desc: 'description',
+              ep_duration: '20:10',
+              ep_name: 'n',
+              ep_name_cn: 'nnn',
+              ep_sort: '0',
+              ep_type: '0',
+            },
+          },
+        ],
         creator: 1,
         now: new Date(),
         comment: 'test',

--- a/routes/private/routes/wiki/subject/ep.ts
+++ b/routes/private/routes/wiki/subject/ep.ts
@@ -220,16 +220,20 @@ export async function setup(app: App) {
 
       await db.transaction(async (t) => {
         await pushRev(t, {
-          episodeID,
-          rev: {
-            ep_airdate: ep.date,
-            ep_desc: ep.summary,
-            ep_duration: ep.duration,
-            ep_name: ep.name,
-            ep_name_cn: ep.nameCN,
-            ep_sort: '0',
-            ep_type: '0',
-          },
+          revisions: [
+            {
+              episodeID,
+              rev: {
+                ep_airdate: ep.date,
+                ep_desc: ep.summary,
+                ep_duration: ep.duration,
+                ep_name: ep.name,
+                ep_name_cn: ep.nameCN,
+                ep_sort: '0',
+                ep_type: '0',
+              },
+            },
+          ],
           creator: auth.userID,
           now,
           comment: commitMessage,


### PR DESCRIPTION
想了一下，如果进一步将 `updatePreviousRevRecords` 和 `createRevRecords` 批处理化好像会让代码太过复杂，所以就还是一个一个来吧