### PR TITLE
docs: update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ fastify + Drizzle + mercurius
 (或者直接使用 corepack)
 
 ```shell
+npm i -g corepack@latest
 corepack enable
 corepack prepare --activate
 ```


### PR DESCRIPTION
corepack 更新了用于签名的 key，比较高版本的 pnpm 需要最新版的 corepack 才能正常下载运行。